### PR TITLE
Add manual runtime deduction

### DIFF
--- a/core/class/pool.class.php
+++ b/core/class/pool.class.php
@@ -641,6 +641,10 @@ class pool extends eqLogic
                 break;
         }
 
+        // Soustrait le temps de marche forcée des 24 dernières heures
+        $dureeHeures -= $this->manualRuntimeLast24h();
+        $dureeHeures = max($dureeHeures, 0);
+
         list($filtrationSecondes, $filtrationTime) = $this->processingTime($dureeHeures);
 
         if ($this->getConfiguration('Activate_HCHP', '0') == '1') {
@@ -1260,6 +1264,10 @@ class pool extends eqLogic
         // log::add('pool', 'debug', $this->getHumanName() . '$temperatureCalcul=' . $temperatureCalcul);
 
         $dureeHeures = $this->calculateTimeFiltrationWithTemperatureHivernage($temperatureCalcul);
+
+        // Soustrait le temps de marche forcée des 24 dernières heures
+        $dureeHeures -= $this->manualRuntimeLast24h();
+        $dureeHeures = max($dureeHeures, 0);
 
         list($filtrationSecondes, $filtrationTime) = $this->processingTime($dureeHeures);
 
@@ -3604,6 +3612,34 @@ class pool extends eqLogic
 
         // log::add('pool', 'debug', '$return:' . $return);
         return $return;
+    }
+
+    public function manualRuntimeLast24h()
+    {
+        $manualCmd = $this->getCmd(null, 'marcheForcee');
+        if (!is_object($manualCmd)) {
+            return 0;
+        }
+        $start = date('Y-m-d H:i:s', strtotime('-24 hours'));
+        $runtime = 0;
+        $prevValue = 0;
+        $prevDatetime = 0;
+        foreach ($manualCmd->getHistory($start, null) as $history) {
+            if ($history->getValue() == 1 && $prevValue == 0) {
+                $prevDatetime = strtotime($history->getDatetime());
+                $prevValue = 1;
+            }
+            if ($history->getValue() == 0 && $prevValue == 1) {
+                if ($prevDatetime > 0 && strtotime($history->getDatetime()) > $prevDatetime) {
+                    $runtime += strtotime($history->getDatetime()) - $prevDatetime;
+                }
+                $prevValue = 0;
+            }
+        }
+        if ($prevValue == 1) {
+            $runtime += time() - $prevDatetime;
+        }
+        return $runtime / 3600;
     }
 
     /*     * **********************Getteur Setteur*************************** */

--- a/docs/en_US/index.md
+++ b/docs/en_US/index.md
@@ -242,6 +242,7 @@ Dans cet onglet, vous devez définir les équipements permettant de piloter la f
 `Arrêt total` : choisissez l'équipement qui imposera au plugin un arrêt total quel que soit l'évènement. Cela peut par exemple vous permettre d’intervenir sur l’installation en étant sur que la filtration ne démarrera pas.
 
 `Marche forcée` :  choisissez l'équipement qui imposera au plugin le démarrage forcé de la filtration. Notez que l’arrêt total est prioritaire sur la marche forcée.
+Le temps passé en marche forcée est automatiquement déduit du temps de filtration calculé en mode automatique sur les 24&nbsp;dernières heures.
 
 Ces deux équipements reçoivent des types infos.
 Il faut donc y mettre les contacts d'un interrupteur RFXcom ou ZWave ou bien encore l'info d'un virtuel qui vous permettra de piloter la filtration à partir du Dashboard.

--- a/docs/fr_FR/index.md
+++ b/docs/fr_FR/index.md
@@ -242,6 +242,7 @@ Dans cet onglet, vous devez définir les équipements permettant de piloter la f
 `Arrêt total` : choisissez l'équipement qui imposera au plugin un arrêt total quel que soit l'évènement. Cela peut par exemple vous permettre d’intervenir sur l’installation en étant sur que la filtration ne démarrera pas.
 
 `Marche forcée` :  choisissez l'équipement qui imposera au plugin le démarrage forcé de la filtration. Notez que l’arrêt total est prioritaire sur la marche forcée.
+Le temps passé en marche forcée est automatiquement déduit du temps de filtration calculé en mode automatique sur les 24&nbsp;dernières heures.
 
 Ces deux équipements reçoivent des types infos.
 Il faut donc y mettre les contacts d'un interrupteur RFXcom ou ZWave ou bien encore l'info d'un virtuel qui vous permettra de piloter la filtration à partir du Dashboard.


### PR DESCRIPTION
## Summary
- subtract manual filtration time from automatic schedule
- track forced runtime over a rolling 24h window
- document new behaviour in both French and English docs

## Testing
- `php -l core/class/pool.class.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fd0d7a3883319dfa9e8ad8090190