### PR TITLE
Add configurable action delay constant

### DIFF
--- a/core/class/pool.class.php
+++ b/core/class/pool.class.php
@@ -21,8 +21,17 @@
 /* * ***************************Includes********************************* */
 require_once dirname(__FILE__) . '/../../../../core/php/core.inc.php';
 
+// Default delay between actions in seconds. Can be overridden via plugin configuration
+if (!defined('POOL_ACTION_DELAY_SECONDS')) {
+    $delay = config::byKey('action_delay_seconds', 'pool', 2);
+    define('POOL_ACTION_DELAY_SECONDS', (int) $delay);
+}
+
 class pool extends eqLogic
 {
+
+    /** Delay between successive actions */
+    const ACTION_DELAY_SECONDS = POOL_ACTION_DELAY_SECONDS;
 
     /* ************************Methode static*************************** */
 
@@ -407,12 +416,12 @@ class pool extends eqLogic
                         || $this->getCmd(null, 'marcheForcee')->execCmd() == 1
                         || ($this->getCmd(null, 'filtrationHivernage')->execCmd() == 1 && $this->getConfiguration('traitement_hivernage', '0') == '1')
                     ) {
-                        sleep(2);
+                        sleep(self::ACTION_DELAY_SECONDS);
                         $this->traitementOn();
                     }
 
                     if ($this->getCmd(null, 'filtrationSurpresseur')->execCmd() == 1) {
-                        sleep(2);
+                        sleep(self::ACTION_DELAY_SECONDS);
                         $this->surpresseurOn();
                     } else {
                         $this->surpresseurStop();
@@ -420,12 +429,12 @@ class pool extends eqLogic
                 } else {
                     if ($this->getCmd(null, 'traitement')->execCmd() == '1') {
                         $this->traitementStop();
-                        sleep(2);
+                        sleep(self::ACTION_DELAY_SECONDS);
                     }
 
                     if ($this->getCmd(null, 'surpresseur')->execCmd() == '1') {
                         $this->surpresseurStop();
-                        sleep(2);
+                        sleep(self::ACTION_DELAY_SECONDS);
                     }
 
                     $this->filtrationStop();

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -30,6 +30,13 @@ if (!isConnect()) {
 
         <div class="alert alert-success"><b>{{Sauvegarde}} : </b>{{La sauvegarde de la configuration redémarre automatiquement le cron}}</div>
 
+        <div class="form-group">
+            <label class="col-sm-4 control-label" >{{Délai entre actions (s)}}</label>
+            <div class="col-sm-2">
+                <input class="configKey form-control" data-l1key="action_delay_seconds" placeholder="2"/>
+            </div>
+        </div>
+
         <script>
 
             function pool_postSaveConfiguration(){

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -22,6 +22,11 @@ function pool_install()
 {
     log::add('pool', 'debug', 'pool_install()');
 
+    // Default configuration for delay between actions
+    if (config::byKey('action_delay_seconds', 'pool', null) === null) {
+        config::save('action_delay_seconds', 2, 'pool');
+    }
+
     $cron = cron::byClassAndFunction('pool', 'pull');
     if (!is_object($cron)) {
         $cron = new cron();
@@ -39,6 +44,11 @@ function pool_update()
 {
     log::add('pool', 'debug', 'pool_update()');
     log::add('pool', 'error', '!!! Voir le changelog et doc pour les changements !!!');
+
+    // Ensure configuration value exists after update
+    if (config::byKey('action_delay_seconds', 'pool', null) === null) {
+        config::save('action_delay_seconds', 2, 'pool');
+    }
 
     foreach (pool::byType('pool') as $pool) {
         log::add('pool', 'debug', 'update :' . $pool->getHumanName());


### PR DESCRIPTION
## Summary
- add constant `ACTION_DELAY_SECONDS` to `pool` class and use it for action waits
- allow override via plugin configuration

## Testing
- `php -l core/class/pool.class.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842073b37ac8331bcdeabb9ebd0f6ef